### PR TITLE
Fix Connection Issues with HA Mosquitto

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Example config.json
   ```
   {
     "LogLevel":"INFO",
-    "storepath": "/home/pi/picam2",
+    "storepath": "/home/vanluna/picam2",
 
     "camera": {
     "index":0,
@@ -149,7 +149,6 @@ Example config.json
       "port": 8883,
       "username":"<USERNAME>",
       "password":"<SECRET>",
-      "insecure":true,
       "connection_retries":3,
       "clientkeyfile":"",
       "clientcertfile":""

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Example config.json
   ```
   {
     "LogLevel":"INFO",
-    "storepath": "/home/vanluna/picam2",
+    "storepath": "/home/pi/picam2",
 
     "camera": {
     "index":0,

--- a/config.json
+++ b/config.json
@@ -50,7 +50,6 @@
 	"port": 8883,
 	"username":"brokerUserName",
 	"password":"brokerPassWD",
-	"insecure":true,
 	"connection_retries":3,
 	"clientkeyfile":"",
 	"clientcertfile":""

--- a/picamclient.py
+++ b/picamclient.py
@@ -764,7 +764,6 @@ class PiCam2Client (mqtt.Client):
                                 cert_reqs=ssl.CERT_REQUIRED)
                 else:
                     logging.info("No Key and Cert")
-                self.tls_insecure_set(self.cfg.MQTTBroker.insecure)
                 self.connect(
                     self.cfg.MQTTBroker.host,
                     self.cfg.MQTTBroker.port)

--- a/picamclient.py
+++ b/picamclient.py
@@ -757,13 +757,13 @@ class PiCam2Client (mqtt.Client):
                     self.cfg.MQTTBroker.username,
                     self.cfg.MQTTBroker.password)
                 # no client certificate needed
-                if len(self.cfg.MQTTBroker.clientcertfile) and \
-                   len(self.cfg.MQTTBroker.clientkeyfile):
-                    self.tls_set(certfile=self.cfg.MQTTBroker.clientcertfile, \
-                                 keyfile=self.cfg.MQTTBroker.clientkeyfile, \
-                                 cert_reqs=ssl.CERT_REQUIRED)
+                if (self.cfg.MQTTBroker.clientcertfile and self.cfg.MQTTBroker.clientkeyfile):
+                    logging.info("Use Key and Cert")
+                    self.tls_set(certfile=self.cfg.MQTTBroker.clientcertfile,
+                                keyfile=self.cfg.MQTTBroker.clientkeyfile,
+                                cert_reqs=ssl.CERT_REQUIRED)
                 else:
-                    self.tls_set(cert_reqs=ssl.CERT_NONE)
+                    logging.info("No Key and Cert")
                 self.tls_insecure_set(self.cfg.MQTTBroker.insecure)
                 self.connect(
                     self.cfg.MQTTBroker.host,


### PR DESCRIPTION
Fixes #4 

Changes:
- Removed MQTTBroker insecure from the client configuration before connect [According to the docs](https://pypi.org/project/paho-mqtt/#client), you should not use this, it is only for testing purposes.

>tls_insecure_set(value)
>Do not use this function in a real system. Setting value to True means there is no point using encryption.

- Removed that same setting from config.json and the sample in the README.
- Added Logging for each leg of the TLS config check.
- Removed the len() around the checking of cert and key values. An empty string "" is False so it is not necessary.

I tested this on my new HA Mosquitto Setup. I was able to see messages arriving in the MQTT Integration, by starting a listener to listen for "#" (wildcard \ all).

I did not test an actual secure setup with certs.

NOTE:  Be sure and select **SQUASH and MERGE** to clean up my messy commit history if you accept the changes.