### PR TITLE
Tweak index.html - spelling and link

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -19,8 +19,8 @@ a:visited { color: #d0d0d0;}
 </head>
 
 <body>
-<h1>MJEPG Stream Live View</h1>
-<p><a href="stream.mjpg"> Full / VLC link</a>, done with <a href="https://github.com/raspberrypi/picamera2" target="_blank">Picamera2</a> and Picam2Ctrl.
+<h1>MJPEG Stream Live View</h1>
+<p><a href="stream.mjpg"> Full / VLC link</a>, done with <a href="https://github.com/raspberrypi/picamera2" target="_blank">Picamera2</a> and <a href="https://github.com/irimitenkan/picam2ctrl" target="_blank">Picam2Ctrl</a>.
 </p>
 
 <img src="stream.mjpg" alt="Picamera2 Stream" width="1152" height="648" class="center"/>


### PR DESCRIPTION
Fixes the `MJEPG` -> `MJPEG` text on the index, and adds a link through to this project.